### PR TITLE
Fix gutter between columns on nested grids

### DIFF
--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -69,11 +69,17 @@ th.column {
   padding-bottom: $column-padding-bottom;
 
   // Prevents Nested columns from double the padding
+  .column.first,
+  .columns.first {
+    padding-left: 0 !important;
+  }
+  .column.last,
+  .columns.last {
+    padding-right: 0 !important;
+  }
+
   .column,
   .columns {
-    padding-left: 0 !important;
-    padding-right: 0 !important;
-
     center {
       min-width: none !important;
     }


### PR DESCRIPTION
Before submitting a pull request, make sure it's targeting the right branch:

- For fixes to Ink 1.0, use `master`.
- For fixes to Foundation for Emails 2, use `v2.0`.

Happy coding! :)

On nested grids, only the outside gutters should be removed, namely the gutter to the left of the first column and the gutter to the right of the last column. The gutter between the columns should be present on nested columns, unless the grid is collapsed.