### PR TITLE
Do not set pixel-width for <center> tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![downloads badge](http://img.shields.io/npm/dm/foundation-emails.svg)](https://www.npmjs.org/package/foundation-emails)
 [![Gem Version](https://badge.fury.io/rb/foundation_emails.svg)](https://badge.fury.io/rb/foundation_emails)
 [![downloads badge](http://img.shields.io/npm/l/foundation-emails.svg)](https://www.npmjs.org/package/foundation-emails)
+[![CDNJS](https://img.shields.io/cdnjs/v/foundation-emails.svg)](https://cdnjs.com/libraries/foundation-emails)
 
 
 Foundation for Emails (previously known as Ink) is a framework for creating responsive HTML emails that work in any email client &mdash; even Outlook. Our HTML/CSS components have been tested across every major email client to ensure consistency. And with the [Inky](https://github.com/zurb/inky) templating language, writing HTML emails is now even easier.

--- a/docs/pages/sass-guide.md
+++ b/docs/pages/sass-guide.md
@@ -168,7 +168,7 @@ Now that you have an inlined email, you'll need to test it in real email clients
 
 The most popular tool for testing emails is [Litmus](https://litmus.com/). All you have to do is paste in the HTML of an email, and you get a live preview in any email client you want.
 
-It's up to you to choose what email clients are important to test in, but you can [see our compatability list](compatibility.html) for recommendations.
+It's up to you to choose what email clients are important to test in, but you can [see our compatibility list](compatibility.html) for recommendations.
 
 ---
 

--- a/scss/components/_normalize.scss
+++ b/scss/components/_normalize.scss
@@ -56,7 +56,6 @@ img {
 
 center {
   width: 100%;
-  min-width: $global-width;
 }
 
 a img {

--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -139,11 +139,6 @@ th.column {
     }
   }
 
-  td.large-#{$i} center,
-  th.large-#{$i} center {
-    min-width: -zf-grid-calc-px($i, $grid-column-count, $global-width) - ($global-gutter * 2);
-  }
-
   .body .columns td.large-#{$i},
   .body .column td.large-#{$i},
   .body .columns th.large-#{$i},


### PR DESCRIPTION
Setting min-width to a pixel-value on the <center> tag breaks the layout if the <center>-tag is inside a nested grid. It should be enough to have width: 100%.

Consider this example:

    <container>
       <row>
          <columns large="10">
             <row>
                <columns large="6">
                   <center>Some centered content</center>
                </columns>
                <columns large="6">
                   <center>Some centered content</center>
                </columns>
             </row>
          </columns>
          <columns large="2">
    Some side-content
          </columns>
       </row>
    </container>

Basing the width of the <center> tags on the size of the containing column doesn't work, since they are within a column with size 6 inside a column with size 10.