### PR TITLE
Fix responsive padding for nested columns

### DIFF
--- a/scss/components/_media-query.scss
+++ b/scss/components/_media-query.scss
@@ -30,13 +30,6 @@
     box-sizing: border-box;
     padding-left: $global-gutter !important;
     padding-right: $global-gutter !important;
-
-    // Nested columns won't double the padding
-    .column,
-    .columns {
-      padding-left: 0 !important;
-      padding-right: 0 !important;
-    }
   }
 
   // Collpased columns have no gutter.


### PR DESCRIPTION
Nested padding should only be removed for the first and last column. This is already covered by https://github.com/Stadly/foundation-emails/commit/9b13d6512113f9163a3a7ab887f5b7842ae91269